### PR TITLE
changed putStrLn *>  to (putStrLn str) *>

### DIFF
--- a/docs/haskell/free-monads.md
+++ b/docs/haskell/free-monads.md
@@ -58,7 +58,7 @@ Finally, we write an "interpreter" turning `Teletype a` values into something we
 interpretTeletype :: Teletype a -> IO a
 interpretTeletype = foldFree run where
   run :: TeletypeF a -> IO a
-  run (PrintLine str x) = putStrLn *> return x
+  run (PrintLine str x) = (putStrLn str ) *> return x
   run (ReadLine f) = fmap f getLine
 
 ```


### PR DESCRIPTION
putStrLn *> return x changed to (putStrLn  str)*> return x
error message when compiling the code produced:
Couldn't match expected type ‘IO a0’
                  with actual type ‘String -> IO ()’
    • Probable cause: ‘putStrLn’ is applied to too few arguments